### PR TITLE
Path errors when the blog post title containing "/" symbol

### DIFF
--- a/l4_author_img.py
+++ b/l4_author_img.py
@@ -188,7 +188,7 @@ def parse_archive_page(url, header, data, author_url, query_num, start_time, end
 
     print("归档页面解析完毕，共获取博客链接数%d，带图片博客数%d" % (blog_num, len(parsed_blog_info)))
     return parsed_blog_info
- 
+
 
 # 用来判断两条博客发布时间是否相同的
 pre_page_last_img_info = {"last_file_time": '', "index": ''}
@@ -423,7 +423,6 @@ def run(author_url, start_time, end_time, target_tags, tags_filter_mode, file_up
 
     deal_file("del")
     print("程序运行结束")
-
 
 if __name__ == "__main__":
     # 一个会出bug的主页 https://silhouette-of-wolf.lofter.com/

--- a/l9_author_txt.py
+++ b/l9_author_txt.py
@@ -27,7 +27,7 @@ def title_filter(title, target_titles):
 def chapter_format(target_titles, blogs_info):
     chapter_infos = {}
     # 以title为key的字典，值为该标题下章节的信息
-    for target_title in target_titles: 
+    for target_title in target_titles:
         chapter_infos[target_title] = []
     # 加入信息
     for blog_info in blogs_info:
@@ -149,6 +149,7 @@ def save_file(blog_infos, author_name, author_ip):
         parse = get_parse(url)
         article_content = parse_template.get_content(parse, template_id, title)
         article = article_head + "\n\n\n\n" + article_content
+        file_name = file_name.replace("/","-")
         with open(arthicle_path + "/" + file_name + ".txt", "w", encoding="utf-8") as op:
             op.write(article)
         print("{} by {} 保存完毕".format(title, author_name))
@@ -184,7 +185,7 @@ def save_chapter(article_infos, target_titles, author_name, author_ip):
             article_content += chapter_content
             print("保存进度{}/{}".format(num, len(chapters_info)))
             num += 1
-
+        file_name = file_name.replace("/","-")
         with open(arthicle_path + "/" + file_name + ".txt", "w", encoding="utf-8") as op:
             op.write(article_content)
         print("{} 保存完成\n".format(target_title))


### PR DESCRIPTION
I changed the code to replace "/" symbols in all post titles to "-" to avoid errors like the following ones:

> 准备保存：✿ 太宰治：致井伏鳟二的三十七封信（13/37） by 花尺一二三，原文连接： https://hanasakuiroha.lofter.com/post/1f0a4ccb_120520e1     Traceback (most recent call last):
>   File "l9_author_txt.py", line 246, in <module>
>     run(author_url, start_time, end_time, target_titles, merger_chapter)
>   File "l9_author_txt.py", line 223, in run
>     save_file(blog_infos, author_name, author_ip)
>   File "l9_author_txt.py", line 152, in save_file
>     with open(arthicle_path + "/" + file_name + ".txt", "w", encoding="utf-8") as op:
> FileNotFoundError: [Errno 2] No such file or directory: './dir/article/花尺一二三/✿ 太宰治：致井伏鳟二的三十七封信（13/37） by 花尺一二三.txt'

Only l4_author_img.py and l9_author_txt.py are changed and tested. Please check the rest of the files if convenient(or if anyone would like to help?) though I did not encounter the same error when crawling with "tag" and "like1".