### PR TITLE
使用 html2text 库修复正文黑体不能正常显示的情况

### DIFF
--- a/l13_like_share_tag.py
+++ b/l13_like_share_tag.py
@@ -7,6 +7,7 @@ import requests
 from urllib import parse
 from lxml.html import etree
 from requests.cookies import RequestsCookieJar
+import html2text
 
 import useragentutil
 
@@ -413,13 +414,7 @@ def infor_formater(fav_infos, fav_str, mode, file_path, start_time, min_hot, pri
         # 正文内容
         content_buf1 = re.search('s\d{1,5}.content="(.*?)";', x).group(1)
         parse = etree.HTML(content_buf1)
-        if content_buf1:
-            f = parse.xpath("//p/text()")
-            content_buf2 = "\n".join(f)
-            content = content_buf2.encode('latin-1').decode("unicode_escape", errors="ignore").strip()
-        else:
-            content = ""
-        blog_info["content"] = content
+        blog_info["content"] = html2text.html2text(content_buf1.encode('latin-1').decode("unicode_escape", errors="ignore"))
 
         # 文章中插的图片
         illustration = []

--- a/小白教程.md
+++ b/小白教程.md
@@ -100,6 +100,8 @@ pip install urllib3
 
 pip install json5
 
+pip install html2text
+
 这是安装运行程序所需要的依赖包
 
 会有三种情况


### PR DESCRIPTION
原程序在爬取正文含有特殊格式的字体(下划线, 黑体, 斜体)时, 会直接忽略这些文字.
可使用 html2text 库完整地将 html 转为文本格式 (markdown-style).